### PR TITLE
Fix for hotkeys to work with --input-default-bindings=no

### DIFF
--- a/pan.lua
+++ b/pan.lua
@@ -16,7 +16,7 @@ function click_handler(table)
         iH = mp.get_property("height")
         vpX = mp.get_property("video-pan-x")
         vpY = mp.get_property("video-pan-y")
-        mp.add_key_binding("mouse_move", "drag-to-pan", function () needs_adjusting = true end)
+        mp.add_forced_key_binding("mouse_move", "drag-to-pan", function () needs_adjusting = true end)
     elseif table["event"] == "up" then
         mp.remove_key_binding("drag-to-pan")
         needs_adjusting = false

--- a/seek-to.lua
+++ b/seek-to.lua
@@ -70,12 +70,12 @@ function set_active()
         end
     end
     for i = 0, 9 do
-        mp.add_key_binding(tostring(i), "seek-to-"..i, function() change_number(i) end)
+        mp.add_forced_key_binding(tostring(i), "seek-to-"..i, function() change_number(i) end)
     end
-    mp.add_key_binding("LEFT", "seek-to-LEFT", function() shift_cursor(true) end)
-    mp.add_key_binding("RIGHT", "seek-to-RIGHT", function() shift_cursor(false) end)
-    mp.add_key_binding("ESC", "seek-to-ESC", set_inactive)
-    mp.add_key_binding("ENTER", "seek-to-ENTER", seek_to)
+    mp.add_forced_key_binding("LEFT", "seek-to-LEFT", function() shift_cursor(true) end)
+    mp.add_forced_key_binding("RIGHT", "seek-to-RIGHT", function() shift_cursor(false) end)
+    mp.add_forced_key_binding("ESC", "seek-to-ESC", set_inactive)
+    mp.add_forced_key_binding("ENTER", "seek-to-ENTER", seek_to)
     show_seeker()
     active = true
 end


### PR DESCRIPTION
When `input-default-bindings=no` is defined in the mpv.conf, the seek-to script doesn't work, because it sets its interactive hotkeys via `add_key_binding`.
This commit changes them to `add_forced_key_binding`.

I left `add_key_binding` for the `Ctrl+t` binding so the user can define it in the input.conf, e.g.:
`F3 script-binding toggle-seeker`