### PR TITLE
Fixed 'encore' typo

### DIFF
--- a/lua-settings/encode_slice.conf
+++ b/lua-settings/encode_slice.conf
@@ -1,6 +1,6 @@
 # profile to slice the current video without reencoding it
 # watch out that the extract will be snapped to keyframes; this is unavoidable when copying streams
-# see encore_webm.conf for a detailed explanations of all the options
+# see encode_webm.conf for a detailed explanations of all the options
 
 container=mkv
 only_active_tracks=yes


### PR DESCRIPTION
Changed `see encore_webm.conf` to `see encode_webm.conf`.