### PR TITLE
Disable hardware decoding when using blur_edges

### DIFF
--- a/scripts/blur-edges.lua
+++ b/scripts/blur-edges.lua
@@ -127,7 +127,10 @@ function toggle()
         active = false
         unset_blur()
         mp.unobserve_property(reset_blur)
+        mp.set_property("hwdec", orig_value_hwdec)
     else
+        orig_value_hwdec = mp.get_property("hwdec")
+        mp.set_property("hwdec", "no")
         active = true
         set_blur()
         local properties = { "osd-width", "osd-height", "path", "fullscreen" }


### PR DESCRIPTION
Hardware decoding will most often interfer with the filter, therefore disable
it when enabling of blur_edges and restore the original value when disabling.

If you think it would be better to implement this feature as an opt-in/opt-out
feature let me know.