### PR TITLE
[crop] Fix subtitle borders being too-wide or too-thin on crop

### DIFF
--- a/script-opts/crop.conf
+++ b/script-opts/crop.conf
@@ -15,6 +15,7 @@ frame_border_color=EEEEEE
 # hexadecimal: 00 is opaque, FF is transparent
 shade_opacity=77
 mouse_support=yes
+fix_borders=yes
 
 # movement is defined in pixels in the window
 # which explains the mismatch with the text (in video space)

--- a/scripts/crop.lua
+++ b/scripts/crop.lua
@@ -8,6 +8,7 @@ local opts = {
     draw_crosshair = true,
     draw_text = true,
     mouse_support = true,
+    fix_borders = true,
     coarse_movement = 30,
     left_coarse = "LEFT",
     right_coarse = "RIGHT",
@@ -299,6 +300,11 @@ function crop_video(x1, y1, x2, y2)
             params= { x = tostring(x), y = tostring(y), w = tostring(w), h = tostring(h) }
         }
         mp.set_property_native("vf", vf_table)
+        local subdata = mp.get_property_native("sub-ass-extradata")
+        if subdata ~= nil and opts.fix_borders then
+            local playresy = subdata:match("PlayResY:%s*(%d+)")
+            mp.set_property_native("sub-ass-force-style", "PlayResX=" .. tostring(tonumber(playresy) * (w/h)))
+        end
     end
 end
 
@@ -392,6 +398,11 @@ function toggle_crop(mode)
                     end
                     vf_table[#vf_table] = nil
                     mp.set_property_native("vf", vf_table)
+                    local subdata = mp.get_property_native("sub-ass-extradata")
+                    if subdata ~= nil and opts.fix_borders then
+                        local playresx = subdata:match("PlayResX:%s*(%d+)")
+                        mp.set_property_native("sub-ass-force-style", "PlayResX=" .. playresx)
+                    end
                     return true
                 end
             end


### PR DESCRIPTION
Depends on: https://github.com/mpv-player/mpv/pull/12256

This is caused by libass 0.17.0 or newer scaling borders, shadows and other stuff in x-axis when it previously used to not do that. To fix it just change the PlayResX when inserting a crop filter.

[fix_border=no](https://github.com/mpv-player/mpv/assets/6298234/6e87074d-be9a-4028-aff4-8d213b7fd3ee) and [fix_border=yes](https://github.com/mpv-player/mpv/assets/6298234/792dfd86-3714-4e7e-8dd6-976146b6137b)