### PR TITLE
Add youtube downloader and fix encode time argument

### DIFF
--- a/script-opts/encode_slice.conf
+++ b/script-opts/encode_slice.conf
@@ -11,3 +11,4 @@ output_directory=
 detached=yes
 ffmpeg_command=ffmpeg
 print=yes
+yt_dlp_command=yt-dlp

--- a/script-opts/encode_webm.conf
+++ b/script-opts/encode_webm.conf
@@ -37,3 +37,6 @@ ffmpeg_command=ffmpeg
 
 # if yes, print the ffmpeg call before executing it
 print=yes
+
+# executable to run for yt-dlp. Similar to ffmpeg_command
+yt_dlp_command=yt-dlp

--- a/scripts/encode.lua
+++ b/scripts/encode.lua
@@ -191,7 +191,7 @@ function start_encoding(from, to, settings)
         input_index = input_index + 1
     end
 
-    append_args({"-to", tostring(to-from)})
+    append_args({"-t", tostring(to-from)})
     append_args(track_args)
 
     local output_args = {}


### PR DESCRIPTION
This PR includes 2 commits. One adding support for downloading videos from YouTube. The other one fixes a bug in the end timestamp.

This pull request is a rewritten version from #55 that only features the `yt-dlp` option, is written more clearly and also applies output arguments properly. Like the original PR it should close #32 and close #46.

Please note that this PR still needs some testing with different YouTube link formats.

Commit messages:
[encode] Allow downloading YouTube videos

This commit adds functionality to download YouTube videos. It uses a
pattern match in case of a stream to ensure the stream is coming from
YouTube. This is done to don't disrupt other stream methods.

Furthermore ffmpeg input and output arguments are getting split since we
need to differentiate between them, if we pass them to youtube dlp. If
we are handling a normal file they just get merged together.

[encode] Fix timespan argument

This replaces the `-to` argument with a `-t`. This is done since `-to`
expects a end timestamp and `-t` expects a time how long the clip should
be. Since we compute how long the clip is we want `-t` instead of `-to`.

This bug was originally introduced in commit
2769f0475c0b1c6d8251386f3cf1cceaafb78ebe