### PR TITLE
Update blacklist-extensions.lua to make remove_files_without_extensions work

### DIFF
--- a/scripts/blacklist-extensions.lua
+++ b/scripts/blacklist-extensions.lua
@@ -46,7 +46,7 @@ function should_remove(filename)
         return false
     end
     local extension = string.match(filename, "%.([^./]+)$")
-    if not extension and opts.remove_file_without_extension then
+    if not extension and opts.remove_files_without_extension then
         return true
     end
     if extension and exclude(string.lower(extension)) then


### PR DESCRIPTION
The option `remove_files_without_extension` was referenced as `remove_file_without_extension` and thus setting it to true had no effect. I added the missing s.