### PR TITLE
[blacklist-extensions.lua] Check if file without extension is directory before removing it from playlist

### DIFF
--- a/scripts/blacklist-extensions.lua
+++ b/scripts/blacklist-extensions.lua
@@ -6,6 +6,7 @@ opts = {
 }
 (require 'mp.options').read_options(opts)
 local msg = require 'mp.msg'
+local utils = require 'mp.utils'
 
 function split(input)
     local ret = {}
@@ -46,7 +47,8 @@ function should_remove(filename)
         return false
     end
     local extension = string.match(filename, "%.([^./]+)$")
-    if not extension and opts.remove_files_without_extension then
+    if not extension and opts.remove_files_without_extension
+    and not utils.file_info(filename).is_dir then
         return true
     end
     if extension and exclude(string.lower(extension)) then


### PR DESCRIPTION
When mpv uses `directory-mode=auto` or `directory-mode=lazy` (the default in mpv 0.37.0 it seems) it adds subdirectories themselves to the playlist instead of their contents, only to expand them when they are played. When `remove_files_without_extension` is set to `true`, directories which do not have a dot in their name are also removed from the playlist. I added a check to prevent this.