### PR TITLE
[blacklist-extensions.lua] Check if playlist entry is directory before removing

### DIFF
--- a/scripts/blacklist-extensions.lua
+++ b/scripts/blacklist-extensions.lua
@@ -6,6 +6,7 @@ opts = {
 }
 (require 'mp.options').read_options(opts)
 local msg = require 'mp.msg'
+local utils = require 'mp.utils'
 
 function split(input)
     local ret = {}
@@ -42,9 +43,13 @@ else
 end
 
 function should_remove(filename)
-    if string.find(filename, "://") then
+
+    -- don't remove playlist entry if it's a stream or directory
+    local file = utils.file_info(filename)
+    if not file or file.is_dir then
         return false
     end
+    
     local extension = string.match(filename, "%.([^./]+)$")
     if not extension and opts.remove_files_without_extension then
         return true


### PR DESCRIPTION
Consider this directory layout:

```
Show/
├── Season 1
├── Season 2
└── Season 3
```

When starting mpv with `mpv Show`, and it's configured with `directory-mode=auto` or `directory-mode=lazy` (the default in mpv 0.37.0 it seems, as I found out after updating), it adds subdirectories themselves to the playlist instead of their contents, only to expand them with their content when they become the current playlist item.

When `remove_files_without_extension` is set to `true` for `blacklist_extensions.lua`, directories which do not have a dot in their name are also removed from the playlist, resulting in:

```
$ mpv Show
[blacklist_extensions] Removed everything from the playlist
Exiting... (No files played)
```

The issue is that `blacklist_extensions.lua` doesn't check whether a playlist entry is a directory before removing it. I added the check, which then also replaced `string.find(filename, "://")` since `utils.file_info(filename)` returns `nil` when filename is a stream URL instead of the path to a local file.